### PR TITLE
Added nonEmpty trait to HalfOpenNoMerge

### DIFF
--- a/llpe/include/llvm/Analysis/ShadowInlines.h
+++ b/llpe/include/llvm/Analysis/ShadowInlines.h
@@ -759,6 +759,9 @@ struct HalfOpenNoMerge {
     return false;
   }
 
+  static inline bool nonEmpty(const uint64_t &a, const uint64_t &b) {
+    return a <= b;
+  }
 };
 
 struct HalfOpenWithMerge {


### PR DESCRIPTION
Without the `nonEmpty` trait I get the following error when compiling for LLVM 7:

```
/path/to/llpe/llpe/main/Eval.cpp:2106:37:   required from here
/usr/include/llvm/ADT/IntervalMap.h:1674:26: error: ‘nonEmpty’ is not a member of ‘llvm::HalfOpenNoMerge’
   assert(Traits::nonEmpty(a, this->stop()) && "Cannot move start beyond stop");
```

I'm not sure if this impacts the other branches.